### PR TITLE
WIP: Added ability to override default input type (ie email or select) for ContractForm

### DIFF
--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -61,11 +61,19 @@ class ContractForm extends Component {
     }
   }
 
+  getType(index, type) { 
+    if(Array.isArray(this.props.inputTypes) && this.props.inputTypes[index]) {
+      return this.props.inputTypes[index];
+    } else {
+      return this.translateType(type);
+    }
+  }
+
   render() {
     return (
       <form className="pure-form pure-form-stacked">
         {this.inputs.map((input, index) => {            
-            var inputType = this.translateType(input.type)
+            var inputType = this.getType(index, input.type)
             var inputLabel = this.props.labels ? this.props.labels[index] : input.name
             // check if input type is struct and if so loop out struct fields as well
             return (<input key={input.name} type={inputType} name={input.name} value={this.state[input.name]} placeholder={inputLabel} onChange={this.handleInputChange} />)

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -27,7 +27,7 @@ class ContractForm extends Component {
             this.inputs = abi[i].inputs;
 
             for (var i = 0; i < this.inputs.length; i++) {
-                initialState[this.inputs[i].name] = '';
+                initialState[this.inputs[i].name] = this.getFixedValue(i) || '';
             }
 
             break;
@@ -69,6 +69,10 @@ class ContractForm extends Component {
     }
   }
 
+  getFixedValue(index) {
+    return Array.isArray(this.props.inputTypes) && this.props.fixedValue[index];
+  }
+
   getInput(inputType, inputName, inputLabel) {
     switch(inputType) {
       case 'textarea':
@@ -82,7 +86,9 @@ class ContractForm extends Component {
   render() {
     return (
       <form className="pure-form pure-form-stacked">
-        {this.inputs.map((input, index) => {            
+        {this.inputs
+          .filter((_, index) => !this.getFixedValue(index))
+          .map((input, index) => {            
             var inputType = this.getType(index, input.type)
             var inputLabel = this.props.labels ? this.props.labels[index] : input.name;
             return this.getInput(inputType, input.name, inputLabel);  

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -77,8 +77,18 @@ class ContractForm extends Component {
     return Array.isArray(this.props.values) && this.props.values[index];
   }
 
-  getInput(inputType, inputName, inputLabel) {
+  getOptions(index) {
+    return Array.isArray(this.props.options) && this.props.options[index];
+  }
+
+  getInput(inputType, inputName, inputLabel, index) {
     switch(inputType) {
+      case 'select': 
+        <select key={inputName} name={inputName} value={this.state[inputName]} onChange={this.handleInputChange}>
+          {this.getOptions(index).map((option) => {
+            return (<option value={option.value}>{option.label}</option>)
+          })}
+        </select>
       case 'textarea':
         return (<textarea key={inputName} name={inputName} value={this.state[inputName]} placeholder={inputLabel} onChange={this.handleInputChange} />);
         break;

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -86,7 +86,7 @@ class ContractForm extends Component {
       case 'select': 
         return <select key={inputName} name={inputName} value={this.state[inputName]} onChange={this.handleInputChange}>
           {this.getOptions(index).map((option) => {
-            return (<option value={option.value}>{option.label}</option>)
+            return (<option key={inputName + option.value} value={option.value}>{option.label}</option>)
           })}
         </select>
         break;

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -87,11 +87,12 @@ class ContractForm extends Component {
     return (
       <form className="pure-form pure-form-stacked">
         {this.inputs
-          .filter((_, index) => !this.getFixedValue(index))
-          .map((input, index) => {            
-            var inputType = this.getType(index, input.type)
-            var inputLabel = this.props.labels ? this.props.labels[index] : input.name;
-            return this.getInput(inputType, input.name, inputLabel);  
+          .map((input, index) => {
+            if (!this.getFixedValue(index)) {
+              var inputType = this.getType(index, input.type)
+              var inputLabel = this.props.labels ? this.props.labels[index] : input.name;
+              return this.getInput(inputType, input.name, inputLabel);  
+            }           
         })}
         <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>Submit</button>
       </form>

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -84,11 +84,12 @@ class ContractForm extends Component {
   getInput(inputType, inputName, inputLabel, index) {
     switch(inputType) {
       case 'select': 
-        <select key={inputName} name={inputName} value={this.state[inputName]} onChange={this.handleInputChange}>
+        return <select key={inputName} name={inputName} value={this.state[inputName]} onChange={this.handleInputChange}>
           {this.getOptions(index).map((option) => {
             return (<option value={option.value}>{option.label}</option>)
           })}
         </select>
+        break;
       case 'textarea':
         return (<textarea key={inputName} name={inputName} value={this.state[inputName]} placeholder={inputLabel} onChange={this.handleInputChange} />);
         break;

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -27,7 +27,7 @@ class ContractForm extends Component {
             this.inputs = abi[i].inputs;
 
             for (var i = 0; i < this.inputs.length; i++) {
-                initialState[this.inputs[i].name] = this.getFixedValue(i) || '';
+                initialState[this.inputs[i].name] = this.getFixedValue(i) || this.getDefaultValue(i) || '';
             }
 
             break;
@@ -71,6 +71,10 @@ class ContractForm extends Component {
 
   getFixedValue(index) {
     return Array.isArray(this.props.inputTypes) && this.props.fixedValue[index];
+  }
+  
+  getDefaultValue(index) {
+    return Array.isArray(this.props.values) && this.props.values[index];
   }
 
   getInput(inputType, inputName, inputLabel) {

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -105,7 +105,7 @@ class ContractForm extends Component {
             if (!this.getFixedValue(index)) {
               var inputType = this.getType(index, input.type)
               var inputLabel = this.props.labels ? this.props.labels[index] : input.name;
-              return this.getInput(inputType, input.name, inputLabel);  
+              return this.getInput(inputType, input.name, inputLabel, index);  
             }           
         })}
         <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>Submit</button>

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -69,14 +69,23 @@ class ContractForm extends Component {
     }
   }
 
+  getInput(inputType, inputName, inputLabel) {
+    switch(inputType) {
+      case 'textarea':
+        return (<textarea key={inputName} name={inputName} value={this.state[inputName]} placeholder={inputLabel} onChange={this.handleInputChange} />);
+        break;
+      default:
+        return (<input key={inputName} type={inputType} name={inputName} value={this.state[inputName]} placeholder={inputLabel} onChange={this.handleInputChange} />)
+    }
+  }
+
   render() {
     return (
       <form className="pure-form pure-form-stacked">
         {this.inputs.map((input, index) => {            
             var inputType = this.getType(index, input.type)
-            var inputLabel = this.props.labels ? this.props.labels[index] : input.name
-            // check if input type is struct and if so loop out struct fields as well
-            return (<input key={input.name} type={inputType} name={input.name} value={this.state[input.name]} placeholder={inputLabel} onChange={this.handleInputChange} />)
+            var inputLabel = this.props.labels ? this.props.labels[index] : input.name;
+            return this.getInput(inputType, input.name, inputLabel);  
         })}
         <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>Submit</button>
       </form>


### PR DESCRIPTION
## Added ability to override default input type for ContractForm

I just want to share this code here so we can discuss which feature would be useful in this repo

This merge request includes the following features:

- Adds an inputTypes property which allows:
    - Ability to override input type (default was based on the contract)
    - Ability to have a select as one of the form field
    - Ability to have a textarea as one of the form field
- Adds fixedValue property which prevent the user from entering a specific value in a field
- Adds defaultValue property which set the initial state of the input.

This code is not ready to merge yet I just wanted to start a discussion around it to see if those features are welcome in the project and which properties should be used to provide these features

