### PR TITLE
Issue #17 Send money over a form, solution suggestion

### DIFF
--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -44,7 +44,7 @@ class ContractForm extends Component {
   handleSubmit() {
     // Get arguments for method and put them into an object
     var args = new Object();
-    if (this.methodArgs == null) {
+    if (this.methodArgs != null) {
       args = JSON.parse(this.methodArgs);
     }
     args.from = this.props.accounts[this.props.accountIndex];    

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -43,7 +43,10 @@ class ContractForm extends Component {
 
   handleSubmit() {
     // Get arguments for method and put them into an object
-    var args = JSON.parse( this.methodArgs );
+    var args = new Object();
+    if (this.methodArgs == null) {
+      args = JSON.parse(this.methodArgs);
+    }
     args.from = this.props.accounts[this.props.accountIndex];    
     this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -18,6 +18,10 @@ class ContractForm extends Component {
     // Get the contract ABI
     const abi = this.contracts[this.props.contract].abi;
 
+    // Fetch methods arguments and index
+    this.methodArgs = this.props.methodArgs ? this.props.methodArgs : [] ;
+    this.accountIndex = this.props.accountIndex ? this.props.accountIndex : [] ;   
+    
     this.inputs = [];
     var initialState = {};
 
@@ -38,7 +42,10 @@ class ContractForm extends Component {
   }
 
   handleSubmit() {
-    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state));
+    // Get arguments for method and put them into an object
+    var args = JSON.parse( this.methodArgs );
+    args.from = this.props.accounts[this.props.accountIndex];    
+    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 
   handleInputChange(event) {
@@ -86,6 +93,8 @@ ContractForm.contextTypes = {
 
 const mapStateToProps = state => {
   return {
+    accounts: state.accounts,
+    accountBalances: state.accountBalances,
     contracts: state.contracts
   }
 }


### PR DESCRIPTION
Solution will allow to send money over the ContractForm:

Simple example how to use it: 

<ContractForm contract="car" 
                          method="rent"       
                          methodArgs='{"value": "1000000000000000000"}'
                          accountIndex="0"
                          labels={['fromDate', 'toDate']}                          
            />

Use no from here. It will be overwritten by the logic up