### PR TITLE
adding value field to ContractForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# drizzle-react-components
-A set of useful components for common UI elements.
+# build
+npm run build
+
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# build
-npm run build
-
+# drizzle-react-components
+A set of useful components for common UI elements.
 
 ## Components
 

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -43,8 +43,9 @@ class ContractForm extends Component {
 
   handleSubmit() {
     // Get arguments for method and put them into an object
-    var args = JSON.parse( this.methodArgs );
-    args.from = this.props.accounts[this.props.accountIndex];    
+    //var args = JSON.parse( this.methodArgs );
+    var args = this.methodArgs[0];
+    //args.from = this.props.accounts[this.props.accountIndex];    
     this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -45,7 +45,7 @@ class ContractForm extends Component {
     // Get arguments for method and put them into an object
     //var args = JSON.parse( this.methodArgs );
     var args = this.methodArgs[0];
-    //args.from = this.props.accounts[this.props.accountIndex];    
+    args.from = this.props.accounts[this.props.accountIndex];    
     this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -18,6 +18,10 @@ class ContractForm extends Component {
     // Get the contract ABI
     const abi = this.contracts[this.props.contract].abi;
 
+    // Fetch methods arguments and index
+    this.methodArgs = this.props.methodArgs ? this.props.methodArgs : [] ;
+    this.accountIndex = this.props.accountIndex ? this.props.accountIndex : [] ;   
+    
     this.inputs = [];
     var initialState = {};
 
@@ -38,7 +42,10 @@ class ContractForm extends Component {
   }
 
   handleSubmit() {
-    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state));
+    // Get arguments for method and put them into an object
+    var args = JSON.parse( this.methodArgs );
+    args.from = this.props.accounts[this.props.accountIndex];    
+    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 
   handleInputChange(event) {
@@ -86,6 +93,8 @@ ContractForm.contextTypes = {
 
 const mapStateToProps = state => {
   return {
+    accounts: state.accounts,
+    accountBalances: state.accountBalances,
     contracts: state.contracts
   }
 }


### PR DESCRIPTION

This patch adds the possibility to specify in ContractForm the amount of wei to send with the transaction (value field).

<ContractForm contract="contract_name" method="method_name" methodArgs={[{from: this.props.accounts[0],value: web3.utils.toWei('2','ether'),data:"Test"}]} />

this is very helpful for calling payable functions.