### PR TITLE
Adding value field support to ContractForm component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# drizzle-react-components
-A set of useful components for common UI elements.
+# build
+npm run build
+
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# build
-npm run build
-
+# drizzle-react-components
+A set of useful components for common UI elements.
 
 ## Components
 

--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -65,7 +65,7 @@ class ContractData extends Component {
     }
 
     // If return value is an array
-    if (typeof displayData === 'array') {
+    if (displayData instanceof Array) {
       const displayListItems = displayData.map((datum, index) => {
         <li key={index}>{datum}{pendingSpinner}</li>
       })

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -43,8 +43,9 @@ class ContractForm extends Component {
 
   handleSubmit() {
     // Get arguments for method and put them into an object
-    var args = JSON.parse( this.methodArgs );
-    args.from = this.props.accounts[this.props.accountIndex];    
+    //var args = JSON.parse( this.methodArgs );
+    var args = this.methodArgs[0];
+    //args.from = this.props.accounts[this.props.accountIndex];    
     this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -41,12 +41,16 @@ class ContractForm extends Component {
     this.state = initialState;
   }
 
-  handleSubmit() {
+ handleSubmit() {
     // Get arguments for method and put them into an object
-    //var args = JSON.parse( this.methodArgs );
-    var args = this.methodArgs[0];
-    args.from = this.props.accounts[this.props.accountIndex];    
-    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
+	var args = this.methodArgs[0];
+      if (typeof args != "undefined") {
+        args = this.methodArgs[0];
+	args.from = this.props.accounts[this.props.accountIndex];    
+	this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
+}
+else
+	this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state));
   }
 
   handleInputChange(event) {

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -45,7 +45,7 @@ class ContractForm extends Component {
     // Get arguments for method and put them into an object
     //var args = JSON.parse( this.methodArgs );
     var args = this.methodArgs[0];
-    //args.from = this.props.accounts[this.props.accountIndex];    
+    args.from = this.props.accounts[this.props.accountIndex];    
     this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -18,6 +18,10 @@ class ContractForm extends Component {
     // Get the contract ABI
     const abi = this.contracts[this.props.contract].abi;
 
+    // Fetch methods arguments and index
+    this.methodArgs = this.props.methodArgs ? this.props.methodArgs : [] ;
+    this.accountIndex = this.props.accountIndex ? this.props.accountIndex : [] ;   
+    
     this.inputs = [];
     var initialState = {};
 
@@ -38,7 +42,10 @@ class ContractForm extends Component {
   }
 
   handleSubmit() {
-    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state));
+    // Get arguments for method and put them into an object
+    var args = JSON.parse( this.methodArgs );
+    args.from = this.props.accounts[this.props.accountIndex];    
+    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state), args);
   }
 
   handleInputChange(event) {
@@ -86,6 +93,8 @@ ContractForm.contextTypes = {
 
 const mapStateToProps = state => {
   return {
+    accounts: state.accounts,
+    accountBalances: state.accountBalances,
     contracts: state.contracts
   }
 }


### PR DESCRIPTION
Fix for https://github.com/trufflesuite/drizzle-react-components/issues/17
This patch adds value field support to ContractData component, making possible to specify the amount of weis to send with the transaction (value field).

`<ContractForm contract="contract_name" method="method_name" methodArgs={[{from: this.props.accounts[0],value: web3.utils.toWei('2','ether'),data:"Test"}]} />
`
this is very helpful for calling payable functions.
Patch tested 