### PR TITLE
Add transaction parameters prop to ContractForm to configure (gas, gasPrice, value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ This components wraps your entire app (but within the DrizzleProvider) and will 
 `method` (string, required) Method whose inputs will be used to create corresponding form fields.
 
 `labels` (array) Custom labels; will follow ABI input ordering. Useful for friendlier names. For example "_to" becoming "Recipient Address".
+
+`txParams` (object) Transaction `gas`, `gasPrice` and `value` values to use when sending transaction. For example `{gas: 32000}` to set the gas limit.

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -91,6 +91,13 @@ ContractForm.contextTypes = {
   drizzle: PropTypes.object
 }
 
+ContractForm.propTypes = {
+  contract: PropTypes.string.isRequired,
+  method: PropTypes.string.isRequired,
+  labels: PropTypes.array,
+  txParams: PropTypes.object
+}
+
 /*
  * Export connected component.
  */

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -37,8 +37,12 @@ class ContractForm extends Component {
     this.state = initialState;
   }
 
+  generateSendArguments () {
+    return this.inputs.map(input => this.state[input.name])
+  }
+
   handleSubmit() {
-    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...Object.values(this.state));
+    this.contracts[this.props.contract].methods[this.props.method].cacheSend(...this.generateSendArguments());
   }
 
   handleInputChange(event) {

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -38,7 +38,14 @@ class ContractForm extends Component {
   }
 
   generateSendArguments () {
-    return this.inputs.map(input => this.state[input.name])
+    let callArgs = this.inputs.map(input => this.state[input.name])
+
+    if(this.props.txParams) {
+      const {gas, gasLimit, gasPrice, value} = this.props.txParams
+      callArgs.push({gas, gasLimit, gasPrice, value})
+    }
+
+    return callArgs
   }
 
   handleSubmit() {


### PR DESCRIPTION
Additional `txParams` prop can be passed to ContractForm to customize gas, gasPrice and value for transaction to be sent.

```
<ContractForm 
    contract='myToken'
    method='transfer' 
    txParams={ ({gas: 30000, gasPrice: 10000000000000, value: 10000000 }) }
/>
```

Builds on #26 