### PR TITLE
Added buttonName to ContractForm to allow changing of Submit name

### DIFF
--- a/src/AccountData.js
+++ b/src/AccountData.js
@@ -43,8 +43,8 @@ class AccountData extends Component {
 
     return(
       <div>
-        <h4>{address}</h4>
-        <p>{balance} {units}</p>
+        <p>Address: {address}</p>
+        <p>Balance: {balance} {units}</p>
       </div>
     )
   }

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -70,7 +70,9 @@ class ContractForm extends Component {
             // check if input type is struct and if so loop out struct fields as well
             return (<input key={input.name} type={inputType} name={input.name} value={this.state[input.name]} placeholder={inputLabel} onChange={this.handleInputChange} />)
         })}
-        <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>Submit</button>
+        <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>
+          {this.props.buttonName ? this.props.buttonName : "Submit"}
+        </button>
       </form>
     )
   }


### PR DESCRIPTION
Created a buttonName prop in ContractForm to allow users to change the Submit button name if required. Shows "submit" if the buttonName prop is not provided. 

Usage:
```
<ContractForm
    contract="TestContract"
    method="testMethod"
    buttonName="New Button Name"
    methodArgs={[]}
/>
```