### PR TITLE
Added render props method to ContractData and to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This components wraps your entire app (but within the DrizzleProvider) and will 
 
 `toAscii` (boolean) Converts the return value to an Ascii string before display.
 
+`render` ((data) => void) Provide your own rendering of the return value.
+
 ### ContractForm
 
 `contract` (string, required) Name of the contract whose method will be the basis the form.

--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -64,6 +64,10 @@ class ContractData extends Component {
       displayData = this.context.drizzle.web3.utils.hexToAscii(displayData)
     }
 
+    if (this.props.render) {
+      return this.props.render(displayData);
+    }
+
     // If return value is an array
     if (typeof displayData === 'array') {
       const displayListItems = displayData.map((datum, index) => {
@@ -77,7 +81,7 @@ class ContractData extends Component {
       )
     }
 
-    // If retun value is an object
+    // If return value is an object
     if (typeof displayData === 'object') {
       var i = 0
       const displayObjectProps = []


### PR DESCRIPTION
Hi,

we needed more control over the rendering to format the result in different ways.

```jsx
<ContractData
    contract="AsureEuroToken"
    method="balanceOf"
    render={data =>
        <div className="myStyle">{Math.floor(data / 10 ** 18)
            .toFixed(2)
            .replace(/\d(?=(\d{3})+\.)/g, '$&,') + ' €'}
        </div>
     }
    methodArgs={[
        this.props.accounts[0],
        { from: this.props.accounts[0] }
    ]}
 />

// Result: 
// <div class="myStyle">100.000.000,00 €</div>
```

