### PR TITLE
Add prop for ContractForm button text

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ This component wraps your entire app (but within the DrizzleProvider) and will s
 `sendArgs` (object) An object specifying options for the transaction to be sent; namely: `from`, `gasPrice`, `gas` and `value`. Further explanataion of these parameters can be found [here in the web3 documentation](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#id19).
 
 `labels` (array) Custom labels; will follow ABI input ordering. Useful for friendlier names. For example "_to" becoming "Recipient Address".
+
+`text` (string) Custom button text; Useful for descriptive buttons. For example "Set Data" and "Set Owner".

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -68,13 +68,13 @@ class ContractForm extends Component {
   render() {
     return (
       <form className="pure-form pure-form-stacked">
-        {this.inputs.map((input, index) => {            
+        {this.inputs.map((input, index) => {
             var inputType = this.translateType(input.type)
             var inputLabel = this.props.labels ? this.props.labels[index] : input.name
             // check if input type is struct and if so loop out struct fields as well
             return (<input key={input.name} type={inputType} name={input.name} value={this.state[input.name]} placeholder={inputLabel} onChange={this.handleInputChange} />)
         })}
-        <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>Submit</button>
+        <button key="submit" className="pure-button" type="button" onClick={this.handleSubmit}>{this.props.text ? this.props.text : 'Submit'}</button>
       </form>
     )
   }


### PR DESCRIPTION
This adds a new prop 'text' to ContractForm that changes the submission button text.

The 'Submit' text is hardcoded:
https://github.com/trufflesuite/drizzle-react-components/blob/master/src/ContractForm.js#L77

```
<ContractForm contract="X" method="X" text="Set Data"/>
<ContractForm contract="X" method="X" text="Set Owner"/>
```