### PR TITLE
Fix/react15 contract data not updating

### DIFF
--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -13,14 +13,27 @@ class ContractData extends Component {
     // Fetch initial value from chain and return cache key for reactive updates.
     var methodArgs = this.props.methodArgs ? this.props.methodArgs : []
 
+    this.contracts = context.drizzle.contracts
     this.state = {
       dataKey: this.contracts[this.props.contract].methods[this.props.method].cacheCall(...methodArgs)
     };
 
-    this.contracts = context.drizzle.contracts
-
     // Get the contract ABI
     const abi = this.contracts[this.props.contract].abi;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { methodArgs, contract, method } = this.props;
+
+    const didContractChange = contract !== nextProps.contract;
+    const didMethodChange = method !== nextProps.method;
+    const didArgsChange = methodArgs && JSON.stringify(methodArgs) !== JSON.stringify(nextProps.methodArgs)
+
+    if (didContractChange || didMethodChange || didArgsChange) {
+      this.setState({
+        dataKey: this.contracts[nextProps.contract].methods[nextProps.method].cacheCall(...nextProps.methodArgs)
+      })
+    }
   }
 
   render() {

--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -22,14 +22,14 @@ class ContractData extends Component {
 
   render() {
     // Contract is not yet intialized.
-    if(!this.props.contracts[this.props.contract].initialized) {
+    if (!this.props.contracts[this.props.contract].initialized) {
       return (
         <span>Initializing...</span>
       )
     }
 
     // If the cache key we received earlier isn't in the store yet; the initial value is still being fetched.
-    if(!(this.dataKey in this.props.contracts[this.props.contract][this.props.method])) {
+    if (!(this.dataKey in this.props.contracts[this.props.contract][this.props.method])) {
       return (
         <span>Fetching...</span>
       )
@@ -61,7 +61,7 @@ class ContractData extends Component {
         <li key={index}>{`${datum}`}{pendingSpinner}</li>
       })
 
-      return(
+      return (
         <ul>
           {displayListItems}
         </ul>
@@ -76,7 +76,7 @@ class ContractData extends Component {
       Object.keys(displayData).forEach((key) => {
         if (i != key) {
           displayObjectProps.push(<li key={i}>
-            <strong>{key}</strong>{pendingSpinner}<br/>
+            <strong>{key}</strong>{pendingSpinner}<br />
             {`${displayData[key]}`}
           </li>)
         }
@@ -84,14 +84,14 @@ class ContractData extends Component {
         i++
       })
 
-      return(
+      return (
         <ul>
           {displayObjectProps}
         </ul>
       )
     }
 
-    return(
+    return (
       <span>{`${displayData}`}{pendingSpinner}</span>
     )
   }

--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -27,7 +27,7 @@ class ContractData extends Component {
 
     const didContractChange = contract !== nextProps.contract;
     const didMethodChange = method !== nextProps.method;
-    const didArgsChange = methodArgs && JSON.stringify(methodArgs) !== JSON.stringify(nextProps.methodArgs)
+    const didArgsChange = JSON.stringify(methodArgs) !== JSON.stringify(nextProps.methodArgs)
 
     if (didContractChange || didMethodChange || didArgsChange) {
       this.setState({

--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -10,14 +10,17 @@ class ContractData extends Component {
   constructor(props, context) {
     super(props)
 
+    // Fetch initial value from chain and return cache key for reactive updates.
+    var methodArgs = this.props.methodArgs ? this.props.methodArgs : []
+
+    this.state = {
+      dataKey: this.contracts[this.props.contract].methods[this.props.method].cacheCall(...methodArgs)
+    };
+
     this.contracts = context.drizzle.contracts
 
     // Get the contract ABI
     const abi = this.contracts[this.props.contract].abi;
-
-    // Fetch initial value from chain and return cache key for reactive updates.
-    var methodArgs = this.props.methodArgs ? this.props.methodArgs : []
-    this.dataKey = this.contracts[this.props.contract].methods[this.props.method].cacheCall(...methodArgs)
   }
 
   render() {
@@ -29,7 +32,7 @@ class ContractData extends Component {
     }
 
     // If the cache key we received earlier isn't in the store yet; the initial value is still being fetched.
-    if (!(this.dataKey in this.props.contracts[this.props.contract][this.props.method])) {
+    if (!(this.state.dataKey in this.props.contracts[this.props.contract][this.props.method])) {
       return (
         <span>Fetching...</span>
       )
@@ -43,7 +46,7 @@ class ContractData extends Component {
       pendingSpinner = ''
     }
 
-    var displayData = this.props.contracts[this.props.contract][this.props.method][this.dataKey].value
+    var displayData = this.props.contracts[this.props.contract][this.props.method][this.state.dataKey].value
 
     // Optionally convert to UTF8
     if (this.props.toUtf8) {


### PR DESCRIPTION
Fixes #4 #13 

Note that this targets React 15 on `master`. Another one will be coming for React 16 on `next`.

You can test this by using `drizzle-box` and just changing accounts on Metamask. You should see the TutorialToken balance update correctly. Only Account 0 should have any balance.

Thanks to @carlosescom @Aare- for their original PRs