### PR TITLE
implements #86: Add Render Props to ContractForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This component wraps your entire app (but within the DrizzleProvider) and will s
 
 `labels` (array) Custom labels; will follow ABI input ordering. Useful for friendlier names. For example "\_to" becoming "Recipient Address".
 
+`render` (function with two arguments) Render property to overwrite form generation. The first argument is an object the maps all method argument names to [react refs](https://reactjs.org/docs/refs-and-the-dom.html). Your form input fields require a `ref` property. Note: [If you use the Material-UI library, the element needs an additional `onChange` property](https://stackoverflow.com/questions/51310609/unable-to-retrieve-the-input-field-of-material-ui-using-refs-in-react-js/55195196#55195196). The second argument is the instant of the `ContractForm`, that means the `ContractForm`s `this`. Use that for calling `ContractForm.setSendArgs` or `ContractForm.handleSubmit` from your render property.
+
 ## Test Apps
 
 A test app targeting the React 16.3+ context API has been included at `./test-app`. And one targeting the legacy context API can be found at `test-app-legacy-context`.
@@ -79,12 +81,12 @@ A test app targeting the React 16.3+ context API has been included at `./test-ap
 ### Installation
 
 1. `cd ./test-app`
-1. Install dependencies: `npm install`
-1. Start your development blockchain: `truffle develop`
-1. (In Truffle develop console) Compile contracts: `compile`
-1. (In Truffle develop console) Migrate contracts: `migrate`
-1. In another terminal window: `cd ./app`
-1. Install dependencies: `npm install`
-1. Start dev server: `npm start`
+2. Install dependencies: `npm install`
+3. Start your development blockchain: `truffle develop`
+4. (In Truffle develop console) Compile contracts: `compile`
+5. (In Truffle develop console) Migrate contracts: `migrate`
+6. In another terminal window: `cd ./app`
+7. Install dependencies: `npm install`
+8. Start dev server: `npm start`
 
 NOTE: Make sure to `migrate --reset` your contracts and reset your Metamask account when switching between test apps, otherwise errors may occur.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "ISC",
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.4.2"
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -8,7 +8,7 @@ class ContractForm extends Component {
 
     this.handleSubmit = this.handleSubmit.bind(this);
 
-    this.sendArgs = props.sendArgs || {};
+    this.sendArgs = {};
 
     this.contracts = context.drizzle.contracts;
     this.utils = context.drizzle.web3.utils;
@@ -47,10 +47,12 @@ class ContractForm extends Component {
       return value;
     });
 
-    if (this.sendArgs) {
+    const sendArgs = Object.assign({}, this.props.sendArgs, this.sendArgs);
+
+    if (sendArgs) {
       return this.contracts[this.props.contract].methods[
         this.props.method
-      ].cacheSend(...convertedInputs, this.sendArgs);
+      ].cacheSend(...convertedInputs, sendArgs);
     }
 
     return this.contracts[this.props.contract].methods[

--- a/src/ContractForm.js
+++ b/src/ContractForm.js
@@ -6,8 +6,9 @@ class ContractForm extends Component {
   constructor(props, context) {
     super(props);
 
-    this.handleInputChange = this.handleInputChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+
+    this.sendArgs = props.sendArgs || {};
 
     this.contracts = context.drizzle.contracts;
     this.utils = context.drizzle.web3.utils;
@@ -16,47 +17,45 @@ class ContractForm extends Component {
     const abi = this.contracts[this.props.contract].abi;
 
     this.inputs = [];
-    var initialState = {};
 
     // Iterate over abi for correct function.
     for (var i = 0; i < abi.length; i++) {
       if (abi[i].name === this.props.method) {
         this.inputs = abi[i].inputs;
 
+        // create references for all values, to be used in the form elements
         for (var j = 0; j < this.inputs.length; j++) {
-          initialState[this.inputs[j].name] = "";
+          this.inputs[j].ref = React.createRef();
         }
-
         break;
       }
     }
+  }
 
-    this.state = initialState;
+  setSendArgs(args) {
+    Object.assign(this.sendArgs, args);
   }
 
   handleSubmit(event) {
     event.preventDefault();
 
-    const convertedInputs = this.inputs.map((input, index) => {
-      if (input.type === 'bytes32') {
-        return this.utils.toHex(this.state[input.name])
+    const convertedInputs = this.inputs.map(input => {
+      var value = input.ref.current !== null ? input.ref.current.value : ""; // default for undefined values
+      if (input.type === "bytes32") {
+        return this.utils.toHex(value);
       }
-      return this.state[input.name];
-    })
+      return value;
+    });
 
-    if (this.props.sendArgs) {
+    if (this.sendArgs) {
       return this.contracts[this.props.contract].methods[
         this.props.method
-      ].cacheSend(...convertedInputs, this.props.sendArgs);
+      ].cacheSend(...convertedInputs, this.sendArgs);
     }
 
     return this.contracts[this.props.contract].methods[
       this.props.method
     ].cacheSend(...convertedInputs);
-  }
-
-  handleInputChange(event) {
-    this.setState({ [event.target.name]: event.target.value });
   }
 
   translateType(type) {
@@ -73,8 +72,22 @@ class ContractForm extends Component {
   }
 
   render() {
+    // If a render prop is given, have displayData rendered from that component
+    if (this.props.render) {
+      // calls render with array of input names and event handler
+      return this.props.render(
+        this.inputs.reduce((map, input) => {
+          map[input.name] = input.ref;
+          return map;
+        }, {}),
+        this,
+      );
+    }
     return (
-      <form className="pure-form pure-form-stacked" onSubmit={this.handleSubmit}>
+      <form
+        className="pure-form pure-form-stacked"
+        onSubmit={this.handleSubmit}
+      >
         {this.inputs.map((input, index) => {
           var inputType = this.translateType(input.type);
           var inputLabel = this.props.labels
@@ -86,9 +99,8 @@ class ContractForm extends Component {
               key={input.name}
               type={inputType}
               name={input.name}
-              value={this.state[input.name]}
+              ref={input.ref}
               placeholder={inputLabel}
-              onChange={this.handleInputChange}
             />
           );
         })}
@@ -114,6 +126,7 @@ ContractForm.propTypes = {
   method: PropTypes.string.isRequired,
   sendArgs: PropTypes.object,
   labels: PropTypes.arrayOf(PropTypes.string),
+  render: PropTypes.func,
 };
 
 /*

--- a/src/new-context-api/ContractForm.js
+++ b/src/new-context-api/ContractForm.js
@@ -7,7 +7,7 @@ class ContractForm extends Component {
 
     this.handleSubmit = this.handleSubmit.bind(this);
 
-    this.sendArgs = props.sendArgs || {};
+    this.sendArgs = {};
 
     this.contracts = props.drizzle.contracts;
     this.utils = props.drizzle.web3.utils;
@@ -47,10 +47,12 @@ class ContractForm extends Component {
       return value;
     });
 
-    if (this.sendArgs) {
+    const sendArgs = Object.assign({}, this.props.sendArgs, this.sendArgs);
+
+    if (sendArgs) {
       return this.contracts[this.props.contract].methods[
         this.props.method
-      ].cacheSend(...convertedInputs, this.sendArgs);
+      ].cacheSend(...convertedInputs, sendArgs);
     }
 
     return this.contracts[this.props.contract].methods[

--- a/test-app-legacy-context/app/package.json
+++ b/test-app-legacy-context/app/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^3.9.2",
     "drizzle": "^1.2.4",
     "drizzle-react": "^1.2.0",
     "drizzle-react-components": "^1.3.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "react-scripts": "2.1.3"
   },
   "scripts": {

--- a/test-app-legacy-context/app/src/MyComponent.js
+++ b/test-app-legacy-context/app/src/MyComponent.js
@@ -4,7 +4,8 @@ import {
   ContractData,
   ContractForm
 } from "drizzle-react-components";
-
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
 import logo from "./logo.png";
 
 const myRender = data => (
@@ -36,7 +37,29 @@ export default ({ accounts }) => (
         <strong>Stored Value: </strong>
         <ContractData contract="SimpleStorage" method="storedData" />
       </p>
-      <ContractForm contract="SimpleStorage" method="set" />
+      <p>
+        Automatically generated form:
+        <ContractForm contract="SimpleStorage" method="set" />
+      </p>
+      <p>
+        Fancy Material-UI form with render prop:
+        <ContractForm
+          contract="SimpleStorage"
+          method="set"
+          render={(inputs, parent) => (
+            <form onSubmit={parent.handleSubmit}>
+              <TextField
+                type="number"
+                ref={inputs.x}
+                onChange={e => {
+                  inputs.x.current.value = e.target.value;
+                }}
+              />
+              <Button onClick={parent.handleSubmit}>Submit</Button>
+            </form>
+          )}
+        />
+      </p>
     </div>
 
     <div className="section">

--- a/test-app/app/package.json
+++ b/test-app/app/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^3.9.2",
     "drizzle": "^1.2.4",
     "drizzle-react": "^1.2.0",
     "drizzle-react-components": "^1.3.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "react-scripts": "2.1.3"
   },
   "scripts": {

--- a/test-app/app/src/MyComponent.js
+++ b/test-app/app/src/MyComponent.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { newContextComponents } from "drizzle-react-components";
 import { DrizzleContext } from "drizzle-react";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
 import logo from "./logo.png";
 
 const { AccountData, ContractData, ContractForm } = newContextComponents;
@@ -56,12 +58,36 @@ export default () => (
                 method="storedData"
               />
             </p>
-            <ContractForm
-              drizzle={drizzle}
-              drizzleState={drizzleState}
-              contract="SimpleStorage"
-              method="set"
-            />
+            <p>
+              Automatically generated form:
+              <ContractForm
+                drizzle={drizzle}
+                drizzleState={drizzleState}
+                contract="SimpleStorage"
+                method="set"
+              />
+            </p>
+            <p>
+              Fancy Material-UI form with render prop:
+              <ContractForm
+                drizzle={drizzle}
+                drizzleState={drizzleState}
+                contract="SimpleStorage"
+                method="set"
+                render={(inputs, parent) => (
+                  <form onSubmit={parent.handleSubmit}>
+                    <TextField
+                      type="number"
+                      ref={inputs.x}
+                      onChange={e => {
+                        inputs.x.current.value = e.target.value;
+                      }}
+                    />
+                    <Button onClick={parent.handleSubmit}>Submit</Button>
+                  </form>
+                )}
+              />
+            </p>
           </div>
 
           <div className="section">


### PR DESCRIPTION
This implements suggestion of #86:
- ContractForm now accepts a render props
- internally, it uses the new `React.createRef()`, which can easily be used from the render function too
- there is a new method `setSendArgs` which allows the render function to change the send args, i.e. to add a `value`
- the render function not only passes the react references, but also `this`, i.e. to allow the render function to call `handleSubmit` and `setSendArgs

@honestbonsai, please give me your feedback about the implemention or accept the pull request,