### PR TITLE
solves #90: fix warnings

### DIFF
--- a/src/ContractData.js
+++ b/src/ContractData.js
@@ -132,7 +132,7 @@ ContractData.contextTypes = {
 };
 
 ContractData.propTypes = {
-  contracts: PropTypes.array.isRequired,
+  contracts: PropTypes.object.isRequired,
   contract: PropTypes.string.isRequired,
   method: PropTypes.string.isRequired,
   methodArgs: PropTypes.array,

--- a/src/LoadingContainer.js
+++ b/src/LoadingContainer.js
@@ -76,7 +76,7 @@ LoadingContainer.contextTypes = {
 
 LoadingContainer.propTypes = {
   children: PropTypes.node,
-  accounts: PropTypes.arrayOf(PropTypes.string).isRequired,
+  accounts: PropTypes.object.isRequired,
   drizzleStatus: PropTypes.object.isRequired,
   web3: PropTypes.object.isRequired,
   loadingComp: PropTypes.node,


### PR DESCRIPTION
Fixes #90 warnings in the console: `ContractForm.propTypes` for contracts and accounts should be `object`, not `array`.